### PR TITLE
[#9]ログイン認証機能を実装する

### DIFF
--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,2 +1,13 @@
 class BaseController < ApplicationController
+  before_action :require_login
+
+  # ユーザーがログインをしていない場合、ログイン画面へ遷移する
+  def require_login
+    redirect_to :login unless logged_in?
+  end
+
+  # セッションからuser_idに紐づくユーザー情報を取得する
+  def logged_in?
+    @user ||= User.find(session[:user_id]) if session[:user_id]
+  end
 end

--- a/app/controllers/base_controller.rb
+++ b/app/controllers/base_controller.rb
@@ -1,6 +1,8 @@
 class BaseController < ApplicationController
   before_action :require_login
 
+  private
+
   # ユーザーがログインをしていない場合、ログイン画面へ遷移する
   def require_login
     redirect_to :login unless logged_in?

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,4 +9,29 @@ class SessionsController < BaseController
       render action: 'new'
     end
   end
+
+  def create
+    @form = LoginForm.new(login_params)
+    user = User.find_by(login_id: @form.login_id)
+
+    if UserAuthenticateService.new(user).authenticate(@form.password)
+      # ユーザー認証成功の処理
+      session[:user_id] = user.id
+      redirect_to :root
+    else
+      # ユーザー認証失敗の処理
+      flash[:danger] = 'ユーザーの認証に失敗しました。'
+      redirect_to action: 'new'
+    end
+  end
+
+  private
+
+  # ログインフォームのストロングパラメーター
+  def login_params
+    params.require(:login_form).permit(
+      :login_id,
+      :password
+    )
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,12 @@
 class SessionsController < BaseController
+  skip_before_action :require_login
+
   def new
-    # TODO: ログイン認証状況によって処理を切り分ける
+    if logged_in?
+      redirect_to :root
+    else
+      @form = LoginForm.new
+      render action: 'new'
+    end
   end
 end

--- a/app/forms/login_form.rb
+++ b/app/forms/login_form.rb
@@ -1,0 +1,5 @@
+class LoginForm
+  include ActiveModel::Model
+
+  attr_accessor :login_id, :password
+end

--- a/app/services/user_authenticate_service.rb
+++ b/app/services/user_authenticate_service.rb
@@ -1,0 +1,13 @@
+class UserAuthenticateService
+  def initialize(user)
+    @user = user
+  end
+
+  # ユーザー認証処理
+  # @param [String] password パスワード文字列
+  # @return [Boolean] true: 認証成功、false: 認証失敗
+  def authenticate(password)
+    @user&.hashed_password &&
+      BCrypt::Password.new(@user&.hashed_password) == password
+  end
+end

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,10 +3,15 @@
 <% end %>
 <div class="login-wrap">
   <h2>Login</h2>
-  <form class="form" id="new_login_form" action="/" accept-charset="UTF-8" method="post">
-    <input required="required" placeholder="ログインID" type="text" name="login_form[login_id]" id="login_form_login_id">
-    <input required="required" placeholder="パスワード" type="password" name="login_form[password]" id="login_form_password">
-    <input type="submit" name="commit" value="ログイン" data-disable-with="ログイン">
+
+  <%= form_for @form, url: :session, html: { class: "form" } do |f| %>
+    <% flash.each do |key, value| %>
+      <%= content_tag(:div, value.html_safe, class: "alert alert-#{key}") %>
+    <% end %>
+    <%= f.text_field :login_id, required: true, :placeholder => "ログインID" %>
+    <%= f.password_field :password, required: true, :placeholder => "パスワード" %>
+    <%= f.submit 'ログイン' %>
+    <% # TODO: アカウントを忘れた場合の処理 %>
     <a href="#"> <p>ログイン情報を忘れたら?</p></a>
-  </form>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@
 #
 
 Rails.application.routes.draw do
-  #root 'top#index'
-  root 'sessions#new'
+  root 'top#index'
+  get 'login' => 'sessions#new', as: :login
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@
 Rails.application.routes.draw do
   root 'top#index'
   get 'login' => 'sessions#new', as: :login
+  resource :session, only: [ :create ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,3 @@
-# == Route Map
-#
-
 Rails.application.routes.draw do
   root 'top#index'
   get 'login' => 'sessions#new', as: :login

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -1,15 +1,72 @@
 require 'rails_helper'
 
 RSpec.describe 'Sessions', type: :request do
-  describe 'GET /new' do
-    it 'レスポンスステータス200が取得されること' do
-      get root_path
-      expect(response).to have_http_status :ok
+  include AuthenticationHelpers
+
+  describe 'GET /login' do
+    describe 'ログイン済みの場合' do
+      let(:user) { create(:user) }
+
+      it 'レスポンスステータス302が取得されること' do
+        login(user, 'password')
+        get login_path
+        expect(response).to have_http_status :found
+      end
+
+      it 'トップ画面へリダイレクトされること' do
+        login(user, 'password')
+        get login_path
+        expect(response).to redirect_to :root
+      end
     end
 
-    it 'new(ログイン画面)テンプレートが表示されること' do
-      get root_path
-      expect(response).to render_template :new
+    describe '未ログインの場合' do
+      it 'レスポンスステータス200が取得されること' do
+        get login_path
+        expect(response).to have_http_status :ok
+      end
+
+      it 'ログイン画面テンプレートが表示されること' do
+        get login_path
+        expect(response).to render_template :new
+      end
+    end
+  end
+
+  describe 'POST /session' do
+    describe 'ログイン情報が正しい場合' do
+      let!(:user) { create(:user) }
+      let(:params) { { login_form: { login_id: user.login_id, password: 'password' } } }
+
+      it 'レスポンスステータス302が取得されること' do
+        post '/session', params: params
+        expect(response).to have_http_status :found
+      end
+
+      it 'トップ画面へリダイレクトされること' do
+        post '/session', params: params
+        expect(response).to redirect_to :root
+      end
+    end
+
+    describe 'ログイン情報に誤りがある場合' do
+      let!(:user) { create(:user) }
+      let(:params) { { login_form: { login_id: user.login_id, password: 'hogehoge' } } }
+
+      it 'レスポンスステータス302が取得されること' do
+        post '/session', params: params
+        expect(response).to have_http_status :found
+      end
+
+      it 'ログイン画面へリダイレクトされること' do
+        post '/session', params: params
+        expect(response).to redirect_to :login
+      end
+
+      it 'エラーメッセージがフラッシュに表示されること' do
+        post '/session', params: params
+        expect(flash[:danger]).to eq 'ユーザーの認証に失敗しました。'
+      end
     end
   end
 end

--- a/spec/requests/top_spec.rb
+++ b/spec/requests/top_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Top', type: :request do
 
   let(:user) { create(:user) }
 
-  describe 'GET /index' do
+  describe 'GET /' do
     describe 'ログイン済みの場合' do
       it 'レスポンスステータス200が取得されること' do
         login(user, 'password')

--- a/spec/requests/top_spec.rb
+++ b/spec/requests/top_spec.rb
@@ -1,16 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe 'Top', type: :request do
+  include AuthenticationHelpers
+
+  let(:user) { create(:user) }
+
   describe 'GET /index' do
-    it 'レスポンスステータス200が取得されること' do
-      get root_path
-      expect(response).to have_http_status :ok
+    describe 'ログイン済みの場合' do
+      it 'レスポンスステータス200が取得されること' do
+        login(user, 'password')
+        get root_path
+        expect(response).to have_http_status :ok
+      end
+
+      it 'index(トップ画面)テンプレートが表示されること' do
+        login(user, 'password')
+        get root_path
+        expect(response).to render_template :index
+      end
     end
 
-    it 'index(Welcome画面)テンプレートが表示されること' do
-      pending
-      get root_path
-      expect(response).to render_template :index
+    describe '未ログインの場合' do
+      it 'レスポンスステータス302が取得されること' do
+        get root_path
+        expect(response).to have_http_status :found
+      end
+
+      it 'ログイン画面へリダイレクトされること' do
+        get root_path
+        expect(response).to redirect_to :login
+      end
     end
   end
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,8 @@
+module AuthenticationHelpers
+  # アプリケーションにログインする
+  # @param [User] user ユーザーモデル
+  # @param [String] password パスワード
+  def login(user, password)
+    post session_path, params: { login_form: { login_id: user.login_id, password: password } }
+  end
+end


### PR DESCRIPTION
# 概要
ログイン認証機能を実装する。

# ISSUE
https://github.com/ayatea/rails-simple-login/issues/9

# スクリーンショット
### 認証成功時
<img width="1465" alt="スクリーンショット 2021-10-13 8 38 58" src="https://user-images.githubusercontent.com/32415417/137043082-4d760bee-5706-4549-b388-0ecde7044f11.png">

### 認証失敗時
<img width="1468" alt="スクリーンショット 2021-10-13 8 38 44" src="https://user-images.githubusercontent.com/32415417/137043113-b33458f4-ff40-4124-9fea-77cfcdd9d380.png">

# 対応
- [x] ログイン状態を確認するアクションを追加する
- [x] ユーザー認証機能を実装する
- [x] Top画面のリクエストテストにログイン機能を反映する
- [x] ログイン画面のリクエストテストにログイン機能を反映

# 動作確認
- [x] rubocopがGREEN
- [x] RSpecがGREEN
